### PR TITLE
Update for use with Guard >=2.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 *.gem
 *.rbc
 .bundle

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
 --color
---format nested
+--format documentation

--- a/guard-foodcritic.gemspec
+++ b/guard-foodcritic.gemspec
@@ -15,8 +15,14 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Guard::FOODCRITIC_VERSION
 
-  gem.add_runtime_dependency "guard", ">= 1.0", "< 3.0"
+  gem.add_runtime_dependency "guard", ">= 2.0", "< 3.0"
   gem.add_runtime_dependency "foodcritic", ">= 1.3", "< 5.0"
+
+  # Add this GEM to make RSPEC tests work with guard >= 2.9
+  # See https://github.com/guard/guard/issues/693 for more details
+  # Note: We need it at runtime too as it decides on the fly whether
+  #  to call guard or mock it.
+  gem.add_runtime_dependency "guard-compat", "~> 1.0"
 
   gem.add_development_dependency "bundler", "~> 1.0"
   gem.add_development_dependency "rake", "~> 10.0"

--- a/lib/guard/foodcritic.rb
+++ b/lib/guard/foodcritic.rb
@@ -1,11 +1,11 @@
-require "guard"
-require "guard/guard"
+#require "guard"
+require "guard/compat/plugin"
 
 module Guard
-  class Foodcritic < Guard
+  class Foodcritic < Plugin
     autoload :Runner, "guard/foodcritic/runner"
 
-    def initialize(watchers=[], options={})
+    def initialize(options={})
       super
 
       @options = {

--- a/lib/guard/foodcritic/version.rb
+++ b/lib/guard/foodcritic/version.rb
@@ -1,3 +1,4 @@
 module Guard
-  FOODCRITIC_VERSION = "1.0.3"
+  # Bump from 1.0.3 to 2.0.0 as this is a breaking change if you have guard 1.x
+  FOODCRITIC_VERSION = "2.0.0"
 end

--- a/spec/guard/foodcritic/runner_spec.rb
+++ b/spec/guard/foodcritic/runner_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "guard/foodcritic/runner"
+require 'guard/compat/plugin'
 
 module Guard
   describe Foodcritic::Runner do
@@ -45,12 +46,12 @@ module Guard
 
       it "returns true when foodcritic suceeds" do
         runner.stub(:system).and_return(true)
-        runner.run([]).should be_true
+        runner.run([]).should be true
       end
 
       it "returns false when foodcritic finds fault" do
         runner.stub(:system).and_return(false)
-        runner.run([]).should be_false
+        runner.run([]).should be false
       end
     end
   end

--- a/spec/guard/foodcritic_spec.rb
+++ b/spec/guard/foodcritic_spec.rb
@@ -1,4 +1,6 @@
 require "spec_helper"
+require 'guard/compat/plugin'
+require 'guard/compat/test/helper'
 require "guard/foodcritic"
 
 module Guard
@@ -8,11 +10,11 @@ module Guard
       UI.stub(:info)
     end
 
-    it { should be_a_kind_of ::Guard::Guard }
+    it { should be_a_kind_of ::Guard::Plugin }
 
     describe "#options" do
       it "[:all_on_start] defaults to true" do
-        described_class.new.options[:all_on_start].should be_true
+        described_class.new.options[:all_on_start].should be true
       end
 
       it "[:cookbook_paths] defaults to ['cookbooks']" do
@@ -20,7 +22,7 @@ module Guard
       end
 
       it "[:notification] defaults to true" do
-        described_class.new.options[:notification].should be_true
+        described_class.new.options[:notification].should be true
       end
     end
 
@@ -74,7 +76,7 @@ module Guard
 
     describe "#run_all" do
       subject { guard.run_all }
-      let(:guard) { described_class.new [], :cookbook_paths => %w(cookbooks site-cookbooks), :notification => notification }
+      let(:guard) { described_class.new :cookbook_paths => %w(cookbooks site-cookbooks), :notification => notification }
       let(:notification) { false }
       let(:runner) { double "runner", :run => true }
       before { guard.stub(:runner).and_return(runner) }
@@ -93,7 +95,7 @@ module Guard
     end
 
     shared_examples "lints specified cookbook files" do
-      let(:guard) { described_class.new([], :notification => notification) }
+      let(:guard) { described_class.new(:notification => notification) }
       let(:notification) { false }
       let(:paths) { %w(recipes/default.rb attributes/default.rb) }
       let(:runner) { double "runner", :run => true }
@@ -146,13 +148,13 @@ module Guard
 
     describe "#start" do
       it "runs all on start if the :all_on_start option is set to true" do
-        guard = described_class.new([], :all_on_start => true)
+        guard = described_class.new(:all_on_start => true)
         guard.should_receive(:run_all)
         guard.start
       end
 
       it "does not run all on start if the :all_on_start option is set to false" do
-        guard = described_class.new([], :all_on_start => false)
+        guard = described_class.new(:all_on_start => false)
         guard.should_not_receive(:run_all)
         guard.start
       end


### PR DESCRIPTION
Hi, been having some issues with various guard plugins since I upgraded to guard 2.11.1
Root cause seems to be some deprecations they made in 2.8 that became hard removals in 2.9.x
Was wondering if you'd be OK to merge this pull request and publish to rubygems.

Best Regards.
Richard.

Commit Message --------------

Guard deprecated reliance on Guard::Guard over a year ago and from 2.8.x
it was displaying deprecation warnings. As of 2.9.x Guard::Guard defined in
guard/guard.rb has been removed breaking plugins that didn't upgrade.

In addition, the new version of Guard breaks many RSpecs because internals
are not initialised if we directly instantiate a plugin. For a discussion
about this issue see https://github.com/guard/guard/issues/693

This commit makes the following changes:-
 - Foodcritic now extends Guard::Plugin instead of Guard::Guard.
 - Initialize method signature now has 1 param (options hash) instead of 2
 - Foodcritic depends on guard-compat to stub out dependencies for RSPEC
 - Updated Specs for deprecated matchers
 - Updated Specs for changed method signature